### PR TITLE
Add TypeScript definitions

### DIFF
--- a/all.d.ts
+++ b/all.d.ts
@@ -1,0 +1,29 @@
+declare module 'fixture-images' {
+  interface IAnimatableImages<T> {
+    gif: T;
+    png: T;
+    jpg: T;
+  }
+
+  interface IStillImages<T> {
+    jpg: T;
+    jxr: T;
+    bmp: T;
+    psd: T;
+    tif: T;
+  }
+
+  interface IImageCollection<T> {
+    still: IStillImages<T> & IAnimatableImages<T>;
+    animated: IAnimatableImages<T>
+  }
+
+  interface IFixtureImages extends IImageCollection<Buffer> {
+    path: IImageCollection<string>;
+    http: IImageCollection<string>;
+    https: IImageCollection<string>;
+  }
+
+  const fixtureImages: IFixtureImages;
+  export = fixtureImages
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "transform": "brfs"
   },
   "main": "all.js",
+  "types": "all.d.ts",
   "files": [
     "all.js",
+    "all.d.ts",
     "animated.GIF",
     "animated.PNG",
     "animated.WEBP",


### PR DESCRIPTION
I would like to use this module with TypeScript. This PR adds type definitions for the exported object.

Please let me know if you need anything else or would like to have something changed.
